### PR TITLE
Include .ts controller files in getAllControllers function

### DIFF
--- a/src/main/kotlin/stimulus/lang/StimulusReferences.kt
+++ b/src/main/kotlin/stimulus/lang/StimulusReferences.kt
@@ -110,7 +110,8 @@ private fun getAllControllers(context: PsiElement): List<JSFile> {
         override fun contains(file: VirtualFile): Boolean {
             val nameSequence = file.nameSequence
             return super.contains(file) &&
-                    (nameSequence.endsWith("_controller.js") || nameSequence.endsWith("-controller.js"))
+                    (nameSequence.endsWith("_controller.js") || nameSequence.endsWith("-controller.js")) ||
+                    (nameSequence.endsWith("_controller.ts") || nameSequence.endsWith("-controller.ts"))
         }
     }
     return getAllControllers(JavaScriptFileType.INSTANCE, context.manager, scope) +


### PR DESCRIPTION
Include Stimulus controllers written in typescript for auto-completion in `data-controller=""` attribute. 
Closes #14.

Let me know if this is sufficient :)